### PR TITLE
Withdraw unsold tokens

### DIFF
--- a/contracts/Sale.sol
+++ b/contracts/Sale.sol
@@ -42,6 +42,11 @@ contract Sale {
         _;
     }
 
+    modifier saleEnded {
+         require(block.number > endBlock);
+         _;
+    }
+
     modifier saleNotEnded {
         require(block.number <= endBlock);
         _;
@@ -215,6 +220,14 @@ contract Sale {
         require(_newOwner != 0);
         owner = _newOwner;
     }
+    
+    function withdrawRemainder()
+         onlyOwner
+         saleEnded
+     {
+         uint remainder = token.balanceOf(this);
+         token.transfer(wallet, remainder);
+     }
 
     function changePrice(uint _newPrice)
         onlyOwner

--- a/test/saleB.js
+++ b/test/saleB.js
@@ -80,5 +80,22 @@ contract('Sale', (accounts) => {
       const finalBalance = await getTokenBalanceOf(james);
       assert.strictEqual(startingBalance.toString(10), finalBalance.toString(10), errMsg);
     });
+
+    it('should allow the owner to withdraw all unsold tokens', async () => {
+      await forceMine(saleConf.endBlock.add(new BN('1', 10)));
+
+      const sale = await Sale.deployed();
+      const startingBalanceSale = await getTokenBalanceOf(sale.address);
+      const owner = await sale.owner.call();
+      await sale.withdrawRemainder({ from: owner });
+      const endingBalanceSale = await getTokenBalanceOf(sale.address);
+      const wallet = await sale.wallet.call();
+      const endingBalanceWallet = await getTokenBalanceOf(wallet);
+
+      const err1 = 'Sale does not have 0 tokens, but should.';
+      const err2 = 'Wallet did not receive withdrawn tokens from sale.';
+      assert.strictEqual(endingBalanceSale.toString(10), '0', err1);
+      assert.strictEqual(endingBalanceWallet.toString(10), startingBalanceSale.toString(10), err2);
+    });
   });
 });


### PR DESCRIPTION
Replacement for #4. This enables the `owner` to withdraw unsold tokens to the `wallet` address once the sale is closed. Without this functionality, the tokens would be burned.